### PR TITLE
Update ExploreYourTextCollection-English.ipynb

### DIFF
--- a/notebooks/English/ExploreYourTextCollection-English.ipynb
+++ b/notebooks/English/ExploreYourTextCollection-English.ipynb
@@ -333,7 +333,7 @@
       "Number of words  17145           \n",
       "Number of unique words 6081            \n",
       "Average word length 6.614289880431612\n",
-      "Average sentence length in characters 12.228579760863225\n",
+      "Average sentence length in characters 75.10314685314685\n",
       "Longest word     Preparation-Inquirers'\n"
      ]
     }
@@ -344,7 +344,7 @@
     "print ('%-16s' % 'Number of unique words', '%-16s' % len(set(sentence_words)))\n",
     "avg=np.sum([len(word) for word in sentence_words])/len(sentence_words)\n",
     "print ('%-16s' % 'Average word length', '%-16s' % avg)\n",
-    "avg_sentence_length_c=np.mean([len(' '.join(sentence)) for sentence in sentence_words])\n",
+    "avg_sentence_length_c=np.mean([len(' '.join(sentence)) for sentence in normalized_sentences_religion])\n",
     "print ('%-16s' % 'Average sentence length in characters', '%-16s' % avg_sentence_length_c)\n",
     "print ('%-16s' % 'Longest word', '%-16s' % sentence_words[np.argmax([len(word) for word in sentence_words])])"
    ]


### PR DESCRIPTION
Bug Fixed: The list of sentences, each of them as a list of their words, should be used instead of the list of all the words to calculate the average length of sentences.